### PR TITLE
[Feat] 토큰 만료 후 자동으로 재발급 되도록 수정

### DIFF
--- a/backend/src/main/java/com/back/fairytale/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/fairytale/global/security/JwtAuthenticationFilter.java
@@ -64,38 +64,61 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         try {
-            // 리프레시 토큰에서 사용자 ID 추출
             Long userId = jwtUtil.getUserId(refreshToken);
-            Optional<User> optionalUser = userRepository.findById(userId);
 
-            if (optionalUser.isEmpty()) {
-                log.warn("리프레시 토큰의 사용자를 찾을 수 없습니다. ID: {}", userId);
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                return;
+            // 동시 요청 동기화
+            synchronized (this.getClass()) {
+                Optional<User> optionalUser = userRepository.findById(userId);
+
+                if (optionalUser.isEmpty()) {
+                    log.warn("리프레시 토큰의 사용자를 찾을 수 없습니다. ID: {}", userId);
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    return;
+                }
+
+                User user = optionalUser.get();
+
+                // 기존 리프레시 토큰과 비교 true면 첫 요청
+                boolean isOriginalToken = refreshToken.equals(user.getRefreshToken());
+                boolean isPreviousToken = false;
+
+                // 최근에 발급된 토큰이 아닌 경우
+                if (!isOriginalToken) {
+                    Long cookieUserId = jwtUtil.getUserId(refreshToken);
+                    isPreviousToken = cookieUserId.equals(userId);
+                }
+
+                if (!isOriginalToken && !isPreviousToken) {
+                    log.warn("리프레시 토큰이 일치하지 않습니다. 사용자 ID: {}", userId);
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    return;
+                }
+
+                if (isOriginalToken) {
+                    String newAccessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().getKey());
+                    String newRefreshToken = jwtProvider.createRefreshToken(user.getId(), user.getRole().getKey());
+
+                    user.setRefreshToken(newRefreshToken);
+                    userRepository.save(user);
+
+                    response.addCookie(jwtProvider.wrapAccessTokenToCookie(newAccessToken));
+                    response.addCookie(jwtProvider.wrapRefreshTokenToCookie(newRefreshToken));
+
+                    log.info("새로운 액세스 토큰이 발급되었습니다. 사용자 ID: {}", userId);
+                } else {
+                    // 이후 요청은 기존 리프레시 토큰으로 액세스 토큰만 재발급
+                    String newAccessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().getKey());
+                    response.addCookie(jwtProvider.wrapAccessTokenToCookie(newAccessToken));
+
+                    log.info("기존 리프레시 토큰으로 액세스 토큰만 재발급. 사용자 ID: {}", userId);
+                }
+
+                CustomOAuth2User customOAuth2User = new CustomOAuth2User(user.getId(), user.getSocialId(), user.getRole().getKey());
+                Authentication authToken = new OAuth2AuthenticationToken(customOAuth2User, customOAuth2User.getAuthorities(), "naver");
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+
+                filterChain.doFilter(request, response);
             }
-
-            User user = optionalUser.get();
-            if(!refreshToken.equals(user.getRefreshToken())) {
-                log.warn("리프레시 토큰이 일치하지 않습니다. 사용자 ID: {}", userId);
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                return;
-            }
-
-            String newAccessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().getKey());
-            String newRefreshToken = jwtProvider.createRefreshToken(user.getId(), user.getRole().getKey());
-            user.setRefreshToken(newRefreshToken);
-            userRepository.save(user);
-
-            response.addCookie(jwtProvider.wrapAccessTokenToCookie(newAccessToken));
-            response.addCookie(jwtProvider.wrapRefreshTokenToCookie(newRefreshToken));
-
-            log.info("새로운 액세스 토큰이 발급되었습니다. 사용자 ID: {}", userId);
-
-            CustomOAuth2User customOAuth2User = new CustomOAuth2User(user.getId(), user.getSocialId(), user.getRole().getKey());
-            Authentication authToken = new OAuth2AuthenticationToken(customOAuth2User, customOAuth2User.getAuthorities(), "naver");
-            SecurityContextHolder.getContext().setAuthentication(authToken);
-
-            filterChain.doFilter(request, response);
 
         } catch (Exception e) {
             log.error("토큰 갱신 중 오류 발생: ", e);

--- a/backend/src/main/java/com/back/fairytale/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/fairytale/global/security/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.back.fairytale.global.security;
 
 import com.back.fairytale.domain.user.entity.User;
 import com.back.fairytale.domain.user.repository.UserRepository;
+import com.back.fairytale.domain.user.service.AuthService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -24,11 +25,13 @@ import java.util.Optional;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
+    private final JWTProvider jwtProvider;
     private final UserRepository userRepository;
+    private final AuthService authService;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return request.getRequestURI().startsWith("/h2-console") || request.getRequestURI().equals("/reissue") ;
+        return request.getRequestURI().startsWith("/h2-console") || request.getRequestURI().equals("/reissue");
     }
 
     @Override
@@ -41,24 +44,79 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (!jwtUtil.validateToken(accessToken)) {
-            log.info("JWT 토큰이 유효하지 않습니다.");
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        if (jwtUtil.validateToken(accessToken)) {
+            log.info("유효한 액세스 토큰입니다.");
+            authenticateUser(accessToken, request, response, filterChain);
             return;
         }
 
+        String refreshToken = getRefreshTokenFromCookies(request);
+        if (refreshToken == null) {
+            log.info("요청에 리프레시 토큰이 없습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!jwtUtil.validateToken(refreshToken)) {
+            log.info("리프레시 토큰이 유효하지 않습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            // 리프레시 토큰에서 사용자 ID 추출
+            Long userId = jwtUtil.getUserId(refreshToken);
+            Optional<User> optionalUser = userRepository.findById(userId);
+
+            if (optionalUser.isEmpty()) {
+                log.warn("리프레시 토큰의 사용자를 찾을 수 없습니다. ID: {}", userId);
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+
+            User user = optionalUser.get();
+            if(!refreshToken.equals(user.getRefreshToken())) {
+                log.warn("리프레시 토큰이 일치하지 않습니다. 사용자 ID: {}", userId);
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+
+            String newAccessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().getKey());
+            String newRefreshToken = jwtProvider.createRefreshToken(user.getId(), user.getRole().getKey());
+            user.setRefreshToken(newRefreshToken);
+            userRepository.save(user);
+
+            response.addCookie(jwtProvider.wrapAccessTokenToCookie(newAccessToken));
+            response.addCookie(jwtProvider.wrapRefreshTokenToCookie(newRefreshToken));
+
+            log.info("새로운 액세스 토큰이 발급되었습니다. 사용자 ID: {}", userId);
+
+            CustomOAuth2User customOAuth2User = new CustomOAuth2User(user.getId(), user.getSocialId(), user.getRole().getKey());
+            Authentication authToken = new OAuth2AuthenticationToken(customOAuth2User, customOAuth2User.getAuthorities(), "naver");
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+
+            filterChain.doFilter(request, response);
+
+        } catch (Exception e) {
+            log.error("토큰 갱신 중 오류 발생: ", e);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+    }
+
+    private void authenticateUser(String accessToken, HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         Long id = jwtUtil.getUserId(accessToken);
         Optional<User> optionalUser = userRepository.findById(id);
+
         if (optionalUser.isEmpty()) {
             log.warn("사용자를 찾을 수 없습니다. ID: {}", id);
             filterChain.doFilter(request, response);
             return;
         }
-        User user = optionalUser.get();
 
+        User user = optionalUser.get();
         CustomOAuth2User customOAuth2User = new CustomOAuth2User(user.getId(), user.getSocialId(), user.getRole().getKey());
         Authentication authToken = new OAuth2AuthenticationToken(customOAuth2User, customOAuth2User.getAuthorities(), "naver");
-
         SecurityContextHolder.getContext().setAuthentication(authToken);
 
         filterChain.doFilter(request, response);
@@ -70,6 +128,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if (cookie.getName().equals("Authorization")) {
+                    token = cookie.getValue();
+                    break;
+                }
+            }
+        }
+        return token;
+    }
+
+    private String getRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        String token = null;
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
                     token = cookie.getValue();
                     break;
                 }

--- a/backend/src/main/java/com/back/fairytale/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/fairytale/global/security/JwtAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return request.getRequestURI().startsWith("/h2-console");
+        return request.getRequestURI().startsWith("/h2-console") || request.getRequestURI().equals("/reissue") ;
     }
 
     @Override


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 반환되는 쿠키를 세션 쿠키로 설정하였습니다.
- 필터에서 액세스 토큰이 유효하지 않을 시 즉시 사용자에게 재발급 되도록 구현했습니다.
- 동시성 문제가 발생하여 필터에서 동기화를 진행하여 리프레시 토큰이 발급되도록 하였습니다. 하지만 모든 요청을 검사하는 필터에서 동기화를 진행하므로 리팩토링이 필요할 것 같습니다.
Close #135 
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
